### PR TITLE
Improve documentation and demo

### DIFF
--- a/plugin/index.ts
+++ b/plugin/index.ts
@@ -1,3 +1,7 @@
+/**
+ * Entry point for the Symbols Icons Figma plugin.
+ * Handles communication between the UI and the Figma API.
+ */
 import { getSerializedSelection } from './serialize';
 import template from '../shared/sfSymbol/template.svg';
 import { IFormGithub, IJsonType } from '../shared/types/typings';
@@ -50,6 +54,9 @@ figma.ui.onmessage = async (msg) => {
 };
 
 figma.on('selectionchange', () => sendSelectedNode());
+/**
+ * Sends the currently selected nodes to the UI.
+ */
 
 const sendSelectedNode = () => {
   const nodes = figma.currentPage.selection
@@ -79,6 +86,9 @@ const sendSelectedNode = () => {
     files: nodes,
   });
 };
+/**
+ * Serialize nodes and post them back to the UI.
+ */
 
 const sendSerializedSelection = async (
   selection: readonly SceneNode[],
@@ -91,6 +101,9 @@ const sendSerializedSelection = async (
     files: svgs,
   });
 };
+/**
+ * Commit generated files directly to GitHub using the provided form data.
+ */
 
 const commitToGithub = async (form: IFormGithub): Promise<void> => {
   const {

--- a/plugin/serialize.ts
+++ b/plugin/serialize.ts
@@ -1,10 +1,22 @@
 import { ISerializedSVG } from '../shared/types/typings';
+/**
+ * Serialize a list of nodes from the current selection into SVG strings.
+ *
+ * @param selection - Nodes to export.
+ * @returns Promise resolving with the serialized SVG objects.
+ */
 
 export const getSerializedSelection = async (
   selection: readonly SceneNode[],
 ): Promise<ISerializedSVG[]> =>
   await Promise.all(selection.map((node) => serialize(node)));
 
+/**
+ * Export a single node as SVG and return its metadata.
+ *
+ * @param node - Node to serialize.
+ * @returns Serialized SVG information.
+ */
 const serialize = async (node: SceneNode): Promise<ISerializedSVG> => {
   const svg: string = await node
     .exportAsync({ format: 'SVG' })

--- a/readme.md
+++ b/readme.md
@@ -1,0 +1,34 @@
+# Symbols Icons
+
+A Figma plugin to export selected vector layers as a set of icons. The plugin can
+output several formats such as:
+
+- individual SVG files
+- an SVG sprite using `<symbol>` elements
+- JSON metadata describing each icon
+- SF Symbols compatible SVGs
+- an optional HTML demo showing all icons
+
+## Development
+
+Install the dependencies and start both the plugin and UI in watch mode:
+
+```bash
+npm install
+npm run dev
+```
+
+The compiled plugin will be placed in `dist/` and can be loaded into Figma for
+development.
+
+To create a production build run:
+
+```bash
+npm run build
+```
+
+## Example page
+
+The `shared/example` folder contains a small demo used when exporting the
+`example` option. Open `index.html` in a browser to preview your icons. Each icon
+includes a button that copies its name to the clipboard.

--- a/shared/example/generateExample.ts
+++ b/shared/example/generateExample.ts
@@ -1,3 +1,6 @@
+/**
+ * Generate the example HTML files used to preview exported icons.
+ */
 import { IJsonType } from '../types/typings';
 
 export interface ExampleFile {
@@ -5,6 +8,13 @@ export interface ExampleFile {
   content: string;
 }
 
+/**
+ * Create an example project containing HTML, CSS and JS for preview.
+ *
+ * @param json - Icon metadata list.
+ * @param symbol - The generated SVG sprite.
+ * @returns Files to be written to disk.
+ */
 export function generateExample(
   json: IJsonType[],
   symbol: string,
@@ -14,30 +24,32 @@ export function generateExample(
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Icons Demo</title>
+  <title>Icon Preview</title>
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <h1>Icons Demo</h1>
+  <header>
+    <h1>Icon Preview</h1>
+    <div class="format">
+      <label for="format">View as:</label>
+      <select id="format">
+        <option value="grid">Grid</option>
+        <option value="list">List</option>
+      </select>
+    </div>
+  </header>
   <div id="symbols" style="display:none">${symbol}</div>
-  <div class="format">
-    <label for="format">Format:</label>
-    <select id="format">
-      <option value="list">List</option>
-      <option value="grid">Grid</option>
-    </select>
-  </div>
-  <ul id="icons" class="list"></ul>
+  <ul id="icons" class="grid"></ul>
   <script src="script.js"></script>
 </body>
 </html>`;
 
-  const css = `body{font-family:sans-serif;margin:20px;}\n#icons.list li{display:flex;align-items:center;margin-bottom:8px;}\n#icons.grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(80px,1fr));gap:16px;padding:0;}\n#icons li{list-style:none;}\n.icon{width:40px;height:40px;margin-right:8px;}\n.format{margin-bottom:16px;}`;
+  const css = `body{font-family:system-ui,sans-serif;margin:20px;background:#f9fafb;color:#1f2937}#icons{display:grid;grid-template-columns:repeat(auto-fill,minmax(100px,1fr));gap:16px;padding:0}#icons.list{grid-template-columns:1fr}#icons li{list-style:none;background:#fff;border:1px solid #e5e7eb;border-radius:6px;padding:8px;display:flex;flex-direction:column;align-items:center;gap:4px;box-shadow:0 1px 2px rgba(0,0,0,0.05)}.icon{width:40px;height:40px}.copy-btn{padding:2px 6px;font-size:12px;border:none;border-radius:4px;background:#e5e7eb;cursor:pointer}.copy-btn:active{background:#d1d5db}`;
 
   const names = json.map((i) => ({ name: i.name }));
   const js = `/* eslint-env browser */\n/* global document */\nconst icons=${JSON.stringify(
     names,
-  )};\nfunction load(){const list=document.getElementById('icons');list.innerHTML='';icons.forEach(icon=>{const li=document.createElement('li');li.innerHTML='<svg class="icon"><use href="#'+icon.name+'"></use></svg><span>'+icon.name+'</span>';list.appendChild(li);});}document.getElementById('format').addEventListener('change',e=>{document.getElementById('icons').className=e.target.value;});load();`;
+  )};\nfunction load(){const list=document.getElementById('icons');list.innerHTML='';icons.forEach(icon=>{const li=document.createElement('li');li.innerHTML='<svg class="icon"><use href="#'+icon.name+'"></use></svg><span>'+icon.name+'</span><button class="copy-btn" data-name="'+icon.name+'">Copy</button>';li.querySelector("button").addEventListener("click",e=>{const n=e.currentTarget.getAttribute("data-name");navigator.clipboard.writeText(n);e.currentTarget.textContent="Copied!";setTimeout(()=>{e.currentTarget.textContent="Copy"},1e3)});list.appendChild(li);});}document.getElementById('format').addEventListener('change',e=>{document.getElementById('icons').className=e.target.value});document.getElementById('icons').className='grid';load();`;
 
   return [
     { name: 'index.html', content: html },

--- a/shared/example/index.html
+++ b/shared/example/index.html
@@ -3,20 +3,22 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Symbol Icons Demo</title>
+  <title>Icon Preview</title>
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <h1>Symbol Icons Demo</h1>
+  <header>
+    <h1>Icon Preview</h1>
+    <div class="format">
+      <label for="format">View as:</label>
+      <select id="format">
+        <option value="grid">Grid</option>
+        <option value="list">List</option>
+      </select>
+    </div>
+  </header>
   <div id="symbols-container" style="display:none"></div>
-  <div class="format">
-    <label for="format">Format:</label>
-    <select id="format">
-      <option value="list">List</option>
-      <option value="grid">Grid</option>
-    </select>
-  </div>
-  <ul id="icons-list" class="list"></ul>
+  <ul id="icons-list" class="grid"></ul>
   <script src="script.js"></script>
 </body>
 </html>

--- a/shared/example/script.js
+++ b/shared/example/script.js
@@ -14,7 +14,18 @@ async function loadIcons() {
   list.innerHTML = '';
   icons.forEach((icon) => {
     const li = document.createElement('li');
-    li.innerHTML = `<svg class="icon"><use href="#${icon.name}"></use></svg><span>${icon.name}</span>`;
+    li.innerHTML = `\
+      <svg class="icon"><use href="#${icon.name}"></use></svg>\
+      <span>${icon.name}</span>\
+      <button class="copy-btn" data-name="${icon.name}">Copy</button>`;
+    li.querySelector('button').addEventListener('click', (e) => {
+      const name = e.currentTarget.getAttribute('data-name');
+      navigator.clipboard.writeText(name);
+      e.currentTarget.textContent = 'Copied!';
+      setTimeout(() => {
+        e.currentTarget.textContent = 'Copy';
+      }, 1000);
+    });
     list.appendChild(li);
   });
 }
@@ -25,3 +36,4 @@ document.getElementById('format').addEventListener('change', (e) => {
 
 loadSymbols();
 loadIcons();
+document.getElementById('icons-list').className = 'grid';

--- a/shared/example/style.css
+++ b/shared/example/style.css
@@ -1,31 +1,55 @@
 body {
-  font-family: sans-serif;
+  font-family: system-ui, sans-serif;
   margin: 20px;
+  background: #f9fafb;
+  color: #1f2937;
 }
 
-#icons-list.list li {
+header {
   display: flex;
   align-items: center;
-  margin-bottom: 8px;
+  justify-content: space-between;
+  margin-bottom: 1rem;
 }
 
-#icons-list.grid {
+#icons-list {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(80px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(100px, 1fr));
   gap: 16px;
   padding: 0;
 }
 
+#icons-list.list {
+  grid-template-columns: 1fr;
+}
+
 #icons-list li {
   list-style: none;
+  background: #fff;
+  border: 1px solid #e5e7eb;
+  border-radius: 6px;
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.05);
 }
 
 .icon {
   width: 40px;
   height: 40px;
-  margin-right: 8px;
 }
 
-.format {
-  margin-bottom: 16px;
+.copy-btn {
+  padding: 2px 6px;
+  font-size: 12px;
+  border: none;
+  border-radius: 4px;
+  background: #e5e7eb;
+  cursor: pointer;
+}
+
+.copy-btn:active {
+  background: #d1d5db;
 }

--- a/shared/jsonFile/convertJsonFile.ts
+++ b/shared/jsonFile/convertJsonFile.ts
@@ -1,6 +1,18 @@
+/**
+ * Convert the list of serialized SVGs into a JSON representation.
+ *
+ * @param files - Serialized SVG information from the plugin.
+ * @returns Array used to generate `icons.json`.
+ */
 import { slugify } from '../utils/slugify';
 import { IJsonType, ISerializedSVG } from '../types/typings';
 
+/**
+ * Build the structure for `icons.json` from raw SVGs.
+ *
+ * @param files - SVG data exported from Figma.
+ * @returns JSON ready to be written to disk.
+ */
 export function generateJsonFile(files: ISerializedSVG[]) {
   const json: IJsonType[] = [];
 

--- a/shared/sfSymbol/convertSFSymbol.ts
+++ b/shared/sfSymbol/convertSFSymbol.ts
@@ -1,3 +1,6 @@
+/**
+ * Utilities to convert exported SVGs into SF Symbols templates.
+ */
 import { load, CheerioAPI } from 'cheerio';
 
 const DEFAULT_ICON_SIZE = 32;
@@ -23,6 +26,10 @@ const SYMBOL_SCALE_ADDITIONS = [
 ];
 const BASE_SYMBOL_SCALE = 0.775;
 
+/**
+ * Read a guide value from the template.
+ * Throws an error when the guide is missing or invalid.
+ */
 function getGuideValue($: CheerioAPI, axis: 'x' | 'y', xmlId: string): number {
   const node = $(`#${xmlId}`);
   if (!node.length) throw new Error(`Guide "${xmlId}" não encontrado`);
@@ -32,6 +39,15 @@ function getGuideValue($: CheerioAPI, axis: 'x' | 'y', xmlId: string): number {
   return parseFloat(v1);
 }
 
+/**
+ * Generate a list of SF Symbol compatible SVGs based on a template.
+ *
+ * @param template - SVG template with guides.
+ * @param icons - Icons exported from Figma.
+ * @param selected - Set of selected size/weight combinations.
+ * @param size - Desired output size.
+ * @returns Array of SF Symbol SVG strings.
+ */
 export function generateSFSymbol(
   template: string,
   icons: { svg: string }[],
@@ -51,6 +67,9 @@ export function generateSFSymbol(
   return sfSymbols;
 }
 
+/**
+ * Internal helper that modifies the template with the icon data.
+ */
 function convertSFSymbol(
   template: string,
   iconSvg: string,

--- a/shared/svgSymbol/convertSvgSymbol.ts
+++ b/shared/svgSymbol/convertSvgSymbol.ts
@@ -1,7 +1,17 @@
+/**
+ * Generate an SVG symbol sprite from a list of exported SVGs.
+ * Each icon becomes a <symbol> element identified by a slugified id.
+ */
 import { load } from 'cheerio';
 import { slugify } from '../utils/slugify';
 import { ISerializedSVG } from '../types/typings';
 
+/**
+ * Build an SVG symbol string containing all icons.
+ *
+ * @param files - Serialized SVG list.
+ * @returns SVG sprite with symbols.
+ */
 export function generateSvgSymbol(files: ISerializedSVG[]): string {
   const $ = load(
     '<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="0" height="0" style="display:none;"></svg>',

--- a/shared/utils/slugify.ts
+++ b/shared/utils/slugify.ts
@@ -1,3 +1,6 @@
+/**
+ * Convert a string into a URL friendly format.
+ */
 export function slugify(name: string): string {
   return name
     .toLowerCase()


### PR DESCRIPTION
## Summary
- document helper functions in plugin and shared utilities
- update README with development instructions
- enhance icon demo page with grid layout and copy buttons

## Testing
- `npm run lint` *(fails: Cannot find package 'globals')*

------
https://chatgpt.com/codex/tasks/task_e_6858720aeac88325927a4595be5406b7