### PR TITLE
Add editable tags support for icons

### DIFF
--- a/plugin/index.ts
+++ b/plugin/index.ts
@@ -28,6 +28,16 @@ figma.ui.onmessage = async (msg) => {
     saveGithubData: async () => {
       await figma.clientStorage.setAsync('githubData', msg.data);
     },
+    setTags: async () => {
+      const node = figma.getNodeById(msg.id);
+      if (node) {
+        try {
+          node.setPluginData('tags', JSON.stringify(msg.tags ?? []));
+        } catch {
+          /* ignore errors */
+        }
+      }
+    },
     setSvgs: async () => {
       const nodes = figma.currentPage.selection;
       void sendSerializedSelection(nodes, 'setSvgs');

--- a/plugin/serialize.ts
+++ b/plugin/serialize.ts
@@ -30,5 +30,13 @@ const serialize = async (node: SceneNode): Promise<ISerializedSVG> => {
     name: node.name,
     id: node.id,
     svg,
+    tags: (() => {
+      try {
+        const data = node.getPluginData('tags');
+        return data ? JSON.parse(data) : [];
+      } catch {
+        return [];
+      }
+    })(),
   };
 };

--- a/shared/jsonFile/convertJsonFile.ts
+++ b/shared/jsonFile/convertJsonFile.ts
@@ -22,6 +22,7 @@ export function generateJsonFile(files: ISerializedSVG[]) {
       svg: file.svg,
       name: slugify(file.name),
       figmaName: file.name,
+      tags: file.tags ?? [],
     });
   });
 

--- a/shared/types/typings.ts
+++ b/shared/types/typings.ts
@@ -3,12 +3,14 @@ export interface IJsonType {
   svg: string;
   name: string;
   figmaName: string;
+  tags?: string[];
 }
 
 export interface ISerializedSVG {
   name: string;
   id: string;
   svg: string;
+  tags?: string[];
 }
 
 export interface IFormGithub {

--- a/testes/generateExample.test.ts
+++ b/testes/generateExample.test.ts
@@ -5,7 +5,13 @@ import {
 } from '../shared/example/generateExample';
 
 const json = [
-  { id: '1', svg: '<svg></svg>', name: 'icon-one', figmaName: 'Icon One' },
+  {
+    id: '1',
+    svg: '<svg></svg>',
+    name: 'icon-one',
+    figmaName: 'Icon One',
+    tags: [],
+  },
 ];
 const sprite = '<svg><symbol id="icon-one"></symbol></svg>';
 

--- a/testes/generateJsonFile.test.ts
+++ b/testes/generateJsonFile.test.ts
@@ -15,12 +15,14 @@ describe('generateJsonFile', () => {
         svg: '<svg></svg>',
         name: 'icon-one',
         figmaName: 'Icon One',
+        tags: [],
       },
       {
         id: '2',
         svg: '<svg></svg>',
         name: 'another-icon',
         figmaName: 'Another Icon',
+        tags: [],
       },
     ]);
   });

--- a/ui/screens/icons-screen.tsx
+++ b/ui/screens/icons-screen.tsx
@@ -39,6 +39,19 @@ export default function IconsScreen() {
   } = useStore();
   const [nodes, setNodes] = useState<SceneNode[]>([]);
   const [loading, setLoading] = useState(false);
+  function handleTagChange(index: number, value: string) {
+    const tags = value
+      .split(',')
+      .map((t) => t.trim())
+      .filter((t) => t.length);
+    const updated = [...jsonFile];
+    updated[index] = { ...updated[index], tags };
+    setJsonFile(updated);
+    parent.postMessage(
+      { pluginMessage: { type: 'setTags', id: updated[index].id, tags } },
+      '*',
+    );
+  }
 
   function downloadBlob(blob: Blob, filename: string) {
     const url = URL.createObjectURL(blob);
@@ -306,13 +319,24 @@ export default function IconsScreen() {
         <div className="grid grid-cols-2 gap-3">
           {jsonFile &&
             jsonFile.map((icon: IJsonType, index: number) => (
-              <div className="flex items-center gap-4 p-4 border border-gray-300 rounded-lg">
-                <svg width={sfSize} height={sfSize} key={index}>
-                  <use xlinkHref={`#${icon.name}`} />
-                </svg>
-                <div className="font-medium text-gray-800 truncate">
-                  <div>{icon.name}</div>
+              <div
+                className="flex flex-col items-start gap-2 p-4 border border-gray-300 rounded-lg"
+                key={index}
+              >
+                <div className="flex items-center gap-4 w-full">
+                  <svg width={sfSize} height={sfSize}>
+                    <use xlinkHref={`#${icon.name}`} />
+                  </svg>
+                  <div className="font-medium text-gray-800 truncate">
+                    <div>{icon.name}</div>
+                  </div>
                 </div>
+                <input
+                  className="form-input w-full rounded border border-gray-300 text-sm p-1"
+                  placeholder="tags (comma separated)"
+                  value={icon.tags?.join(', ') || ''}
+                  onChange={(e) => handleTagChange(index, e.target.value)}
+                />
               </div>
             ))}
         </div>


### PR DESCRIPTION
## Summary
- allow icons to store tags
- include tags when generating JSON export
- save tags in Figma nodes via plugin
- add editable tag input in Export Icons screen
- update tests

## Testing
- `npm test`
- `npm run plugin:tsc`
- `npm run ui:tsc`


------
https://chatgpt.com/codex/tasks/task_e_6859d8bd76a8832596f7d09832d9ef89