### PR TITLE
Add per-output GitHub settings

### DIFF
--- a/plugin/github.ts
+++ b/plugin/github.ts
@@ -1,5 +1,164 @@
 import { IFormGithub } from '../shared/types/typings';
 
+interface CommitGroup {
+  githubToken: string;
+  owner: string;
+  repo: string;
+  branch: string;
+  commitMessage: string;
+  pullRequestTitle: string;
+  mainBranch: string;
+  files: { path: string; content: string }[];
+}
+
+async function commitGroup({
+  githubToken,
+  owner,
+  repo,
+  branch,
+  commitMessage,
+  pullRequestTitle,
+  mainBranch,
+  files,
+}: CommitGroup) {
+  let branchSHA;
+
+  const checkBranchResponse = await fetch(
+    `https://api.github.com/repos/${owner}/${repo}/git/refs/heads/${branch}`,
+    {
+      method: 'GET',
+      headers: {
+        Authorization: `token ${githubToken}`,
+      },
+    },
+  );
+
+  if (checkBranchResponse.status === 404) {
+    const checkMainBranch = await fetch(
+      `https://api.github.com/repos/${owner}/${repo}/git/refs/heads/${mainBranch}`,
+      {
+        method: 'GET',
+        headers: {
+          Authorization: `token ${githubToken}`,
+        },
+      },
+    );
+
+    const shaMainBranch = (await checkMainBranch.json()).object.sha;
+
+    const newBranch = await fetch(
+      `https://api.github.com/repos/${owner}/${repo}/git/refs`,
+      {
+        method: 'POST',
+        headers: {
+          Authorization: `token ${githubToken}`,
+        },
+        body: JSON.stringify({
+          ref: `refs/heads/${branch}`,
+          sha: shaMainBranch,
+        }),
+      },
+    );
+
+    branchSHA = (await newBranch.json()).object.sha;
+  } else {
+    branchSHA = (await checkBranchResponse.json()).object.sha;
+  }
+
+  const changes = await Promise.all(
+    files.map(async (file) => {
+      const blob = await fetch(
+        `https://api.github.com/repos/${owner}/${repo}/git/blobs`,
+        {
+          method: 'POST',
+          headers: {
+            Authorization: `token ${githubToken}`,
+          },
+          body: JSON.stringify({
+            content: fileToBase64(file.content),
+          }),
+        },
+      );
+
+      return {
+        path: file.path,
+        mode: '100644',
+        type: 'blob',
+        sha: (await blob.json()).sha,
+      };
+    }),
+  );
+
+  const getBaseTree = await fetch(
+    `https://api.github.com/repos/${owner}/${repo}/git/trees/${branch}`,
+    {
+      method: 'GET',
+      headers: {
+        Authorization: `token ${githubToken}`,
+      },
+    },
+  );
+
+  const createTree = await fetch(
+    `https://api.github.com/repos/${owner}/${repo}/git/trees`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `token ${githubToken}`,
+      },
+      body: JSON.stringify({
+        base_tree: (await getBaseTree.json()).sha,
+        tree: changes,
+      }),
+    },
+  );
+
+  const createCommit = await fetch(
+    `https://api.github.com/repos/${owner}/${repo}/git/commits`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `token ${githubToken}`,
+      },
+      body: JSON.stringify({
+        message: commitMessage,
+        parents: [branchSHA],
+        tree: (await createTree.json()).sha,
+      }),
+    },
+  );
+
+  const updateBranch = await fetch(
+    `https://api.github.com/repos/${owner}/${repo}/git/refs/heads/${branch}`,
+    {
+      method: 'PATCH',
+      headers: {
+        Authorization: `token ${githubToken}`,
+      },
+      body: JSON.stringify({
+        sha: (await createCommit.json()).sha,
+      }),
+    },
+  );
+
+  if (updateBranch.status !== 200) {
+    console.error('Erro ao criar o arquivo:', (await createTree.json()).message);
+    return;
+  }
+
+  await fetch(`https://api.github.com/repos/${owner}/${repo}/pulls`, {
+    method: 'POST',
+    headers: {
+      Authorization: `token ${githubToken}`,
+    },
+    body: JSON.stringify({
+      title: pullRequestTitle,
+      head: branch,
+      base: mainBranch,
+    }),
+  });
+}
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const fileToBase64 = (file: any) => {
   if (file instanceof Uint8Array) {
@@ -28,210 +187,85 @@ export const commitToGithub = async (
     jsonFile,
     filesName,
     svgs,
+    overrides,
   } = githubData;
 
-  let branchSHA;
-
   try {
-    const checkBranchResponse = await fetch(
-      `https://api.github.com/repos/${owner}/${repo}/git/refs/heads/${branch}`,
-      {
-        method: 'GET',
-        headers: {
-          Authorization: `token ${githubToken}`,
-        },
-      },
-    );
+    const groups: Record<string, CommitGroup> = {};
 
-    if (checkBranchResponse.status === 404) {
-      const checkMainBranch = await fetch(
-        `https://api.github.com/repos/${owner}/${repo}/git/refs/heads/${mainBranch}`,
-        {
-          method: 'GET',
-          headers: {
-            Authorization: `token ${githubToken}`,
-          },
-        },
-      );
-
-      const shaMainBranch = (await checkMainBranch.json()).object.sha;
-
-      const newBranch = await fetch(
-        `https://api.github.com/repos/${owner}/${repo}/git/refs`,
-        {
-          method: 'POST',
-          headers: {
-            Authorization: `token ${githubToken}`,
-          },
-          body: JSON.stringify({
-            ref: `refs/heads/${branch}`,
-            sha: shaMainBranch,
-          }),
-        },
-      );
-
-      branchSHA = (await newBranch.json()).object.sha;
-    } else {
-      branchSHA = (await checkBranchResponse.json()).object.sha;
+    function addFile(
+      key: keyof typeof overrides,
+      relativePath: string,
+      content: string,
+    ) {
+      const cfg = overrides[key];
+      const o = cfg.owner || owner;
+      const r = cfg.repo || repo;
+      const p = cfg.path || filePath;
+      const m = cfg.mainBranch || mainBranch;
+      const groupKey = `${o}|${r}|${p}|${m}`;
+      if (!groups[groupKey]) {
+        groups[groupKey] = {
+          githubToken,
+          owner: o,
+          repo: r,
+          branch,
+          commitMessage,
+          pullRequestTitle,
+          mainBranch: m,
+          files: [],
+        };
+      }
+      groups[groupKey].files.push({ path: `${p}/${relativePath}`, content });
     }
 
-    const files: { path: string; content: string }[] = [];
-
     if (outputs.json) {
-      files.push({
-        path: `${filePath}/${filesName}.json`,
-        content: JSON.stringify(jsonFile, null, 2),
-      });
+      addFile('json', `${filesName}.json`, JSON.stringify(jsonFile, null, 2));
     }
 
     if (outputs.symbol) {
-      files.push({
-        path: `${filePath}/${filesName}-defs.svg`,
-        content: svgSymbol,
-      });
+      addFile('symbol', `${filesName}-defs.svg`, svgSymbol);
     }
 
     if (outputs.svg && svgs) {
       svgs.forEach((icon) => {
-        files.push({
-          path: `${filePath}/svgs/${icon.name}.svg`,
-          content: icon.svg,
-        });
+        addFile('svg', `svgs/${icon.name}.svg`, icon.svg);
       });
     }
 
     if (outputs.sf && svgs) {
       sfSymbols.forEach((symbol, idx) => {
-        files.push({
-          path: `${filePath}/${svgs[idx].name}/${svgs[idx].name}.svg`,
-          content: symbol,
-        });
-        files.push({
-          path: `${filePath}/${svgs[idx].name}/Contents.json`,
-          content: JSON.stringify(
+        addFile(
+          'sf',
+          `${svgs[idx].name}/${svgs[idx].name}.svg`,
+          symbol,
+        );
+        addFile(
+          'sf',
+          `${svgs[idx].name}/Contents.json`,
+          JSON.stringify(
             {
-              info: {
-                author: 'xcode',
-                version: 1,
-              },
+              info: { author: 'xcode', version: 1 },
               symbols: [
-                {
-                  filename: `${svgs[idx].name}.svg`,
-                  idiom: 'universal',
-                },
+                { filename: `${svgs[idx].name}.svg`, idiom: 'universal' },
               ],
             },
             null,
             2,
           ),
-        });
+        );
       });
     }
 
     if (outputs.example) {
       exampleFiles.forEach((f: { name: string; content: string }) => {
-        files.push({
-          path: `${filePath}/${f.name}`,
-          content: f.content,
-        });
+        addFile('example', f.name, f.content);
       });
     }
 
-    const changes = await Promise.all(
-      files.map(async (file) => {
-        const blob = await fetch(
-          `https://api.github.com/repos/${owner}/${repo}/git/blobs`,
-          {
-            method: 'POST',
-            headers: {
-              Authorization: `token ${githubToken}`,
-            },
-            body: JSON.stringify({
-              content: fileToBase64(file.content),
-            }),
-          },
-        );
-
-        return {
-          path: file.path,
-          mode: '100644',
-          type: 'blob',
-          sha: (await blob.json()).sha,
-        };
-      }),
-    );
-
-    const getBaseTree = await fetch(
-      `https://api.github.com/repos/${owner}/${repo}/git/trees/${branch}`,
-      {
-        method: 'GET',
-        headers: {
-          Authorization: `token ${githubToken}`,
-        },
-      },
-    );
-
-    const createTree = await fetch(
-      `https://api.github.com/repos/${owner}/${repo}/git/trees`,
-      {
-        method: 'POST',
-        headers: {
-          Authorization: `token ${githubToken}`,
-        },
-        body: JSON.stringify({
-          base_tree: (await getBaseTree.json()).sha,
-          tree: changes,
-        }),
-      },
-    );
-
-    const createCommit = await fetch(
-      `https://api.github.com/repos/${owner}/${repo}/git/commits`,
-      {
-        method: 'POST',
-        headers: {
-          Authorization: `token ${githubToken}`,
-        },
-        body: JSON.stringify({
-          message: commitMessage,
-          parents: [branchSHA],
-          tree: (await createTree.json()).sha,
-        }),
-      },
-    );
-
-    const updateBranch = await fetch(
-      `https://api.github.com/repos/${owner}/${repo}/git/refs/heads/${branch}`,
-      {
-        method: 'PATCH',
-        headers: {
-          Authorization: `token ${githubToken}`,
-        },
-        body: JSON.stringify({
-          sha: (await createCommit.json()).sha,
-        }),
-      },
-    );
-
-    if (updateBranch.status !== 200) {
-      console.error(
-        'Erro ao criar o arquivo:',
-        (await createTree.json()).message,
-      );
-      return;
+    for (const key of Object.keys(groups)) {
+      await commitGroup(groups[key]);
     }
-
-    await fetch(`https://api.github.com/repos/${owner}/${repo}/pulls`, {
-      method: 'POST',
-      headers: {
-        Authorization: `token ${githubToken}`,
-      },
-      body: JSON.stringify({
-        title: pullRequestTitle,
-        head: branch,
-        base: mainBranch,
-      }),
-    });
   } catch (error) {
     console.error('Erro ao comitar arquivo e abrir PR:', error);
   }

--- a/shared/types/typings.ts
+++ b/shared/types/typings.ts
@@ -13,6 +13,13 @@ export interface ISerializedSVG {
   tags?: string[];
 }
 
+export interface OutputGithubConfig {
+  path: string;
+  owner: string;
+  repo: string;
+  mainBranch: string;
+}
+
 export interface IFormGithub {
   outputs: {
     svg: boolean;
@@ -30,6 +37,13 @@ export interface IFormGithub {
   commitMessage: string;
   pullRequestTitle: string;
   mainBranch: string;
+  overrides: {
+    svg: OutputGithubConfig;
+    symbol: OutputGithubConfig;
+    example: OutputGithubConfig;
+    sf: OutputGithubConfig;
+    json: OutputGithubConfig;
+  };
   exampleFiles: ExampleFile[];
   svgSymbol: string;
   sfSymbols: string[];

--- a/ui/screens/github-screen.tsx
+++ b/ui/screens/github-screen.tsx
@@ -23,13 +23,41 @@ export default function GithubScreen() {
     commitMessage,
     pullRequestTitle,
     mainBranch,
+    overrides,
   } = githubForm;
 
+  const outputLabels: Record<keyof typeof overrides, string> = {
+    svg: 'SVG',
+    symbol: 'Symbol',
+    example: 'Example',
+    sf: 'SF Symbol',
+    json: 'JSON',
+  };
+
   const [loading, setLoading] = useState(false);
+  const [open, setOpen] = useState<Record<string, boolean>>({});
+
+  function toggleAccordion(name: keyof typeof outputs) {
+    setOpen((prev) => ({ ...prev, [name]: !prev[name] }));
+  }
 
   function toggle(name: keyof typeof outputs) {
     const newOutputs = { ...outputs, [name]: !outputs[name] };
     setGithubForm({ ...githubForm, outputs: newOutputs });
+  }
+
+  function updateOverride(
+    output: keyof typeof overrides,
+    field: keyof typeof overrides.svg,
+    value: string,
+  ) {
+    setGithubForm({
+      ...githubForm,
+      overrides: {
+        ...overrides,
+        [output]: { ...overrides[output], [field]: value },
+      },
+    });
   }
 
   function handleSubmit(e: React.FormEvent) {
@@ -48,6 +76,7 @@ export default function GithubScreen() {
       commitMessage,
       pullRequestTitle,
       mainBranch,
+      overrides,
       exampleFiles,
       svgSymbol,
       sfSymbols,
@@ -96,75 +125,61 @@ export default function GithubScreen() {
         </h2>
       </div>
       <form onSubmit={handleSubmit} className="flex flex-col gap-3 px-4 py-4">
-        <div className="grid grid-cols-2 gap-4">
-          <label className="flex items-center p-4 border border-gray-300 rounded-lg cursor-pointer flex-1 bg-white shadow-sm hover:shadow-md transition-shadow">
-            <input
-              className="form-radio h-5 w-5 text-teal-600 border-gray-400 focus:ring-teal-500"
-              name="outputType"
-              type="checkbox"
-              value="svg"
-              checked={outputs.svg}
-              onChange={() => toggle('svg')}
-            />
-            <span className="ml-3 text-gray-700 font-medium">SVG</span>
-          </label>
-          <label className="flex items-center p-4 border border-gray-300 rounded-lg cursor-pointer flex-1 bg-white shadow-sm hover:shadow-md transition-shadow">
-            <input
-              className="form-radio h-5 w-5 text-teal-600 border-gray-400 focus:ring-teal-500"
-              name="outputType"
-              type="checkbox"
-              value="symbol"
-              checked={outputs.symbol}
-              onChange={() => toggle('symbol')}
-            />
-            <span className="ml-3 text-gray-700 font-medium">Symbol</span>
-          </label>
-          <label className="flex items-center p-4 border border-gray-300 rounded-lg cursor-pointer flex-1 bg-white shadow-sm hover:shadow-md transition-shadow">
-            <input
-              className="form-radio h-5 w-5 text-teal-600 border-gray-400 focus:ring-teal-500"
-              name="outputType"
-              type="checkbox"
-              value="sf"
-              checked={outputs.sf}
-              onChange={() => toggle('sf')}
-            />
-            <span className="ml-3 text-gray-700 font-medium">SF Symbol</span>
-          </label>
-          <label className="flex items-center p-4 border border-gray-300 rounded-lg cursor-pointer flex-1 bg-white shadow-sm hover:shadow-md transition-shadow">
-            <input
-              className="form-radio h-5 w-5 text-teal-600 border-gray-400 focus:ring-teal-500"
-              name="outputType"
-              type="checkbox"
-              value="json"
-              checked={outputs.json}
-              onChange={() => toggle('json')}
-            />
-            <span className="ml-3 text-gray-700 font-medium">JSON</span>
-          </label>
-          <label className="flex items-center p-4 border border-gray-300 rounded-lg cursor-pointer flex-1 bg-white shadow-sm hover:shadow-md transition-shadow">
-            <input
-              className="form-radio h-5 w-5 text-teal-600 border-gray-400 focus:ring-teal-500"
-              name="outputType"
-              type="checkbox"
-              value="example"
-              checked={outputs.example}
-              onChange={() => toggle('example')}
-            />
-            <span className="ml-3 text-gray-700 font-medium">Example</span>
-          </label>
-          <label className="flex items-center p-4 border border-gray-200 rounded-lg cursor-not-allowed flex-1 bg-gray-100 shadow-sm opacity-50 select-none">
+        <div className="flex flex-col gap-3">
+          {Object.keys(outputLabels).map((key) => {
+            const k = key as keyof typeof overrides;
+            const label = outputLabels[k];
+            return (
+              <details key={k} open={open[k]} className="border rounded-lg bg-white shadow-sm">
+                <summary className="flex items-center justify-between p-4 cursor-pointer" onClick={() => toggleAccordion(k)}>
+                  <label className="flex items-center cursor-pointer">
+                    <input
+                      className="form-radio h-5 w-5 text-teal-600 border-gray-400 focus:ring-teal-500"
+                      type="checkbox"
+                      checked={outputs[k as keyof typeof outputs]}
+                      onChange={() => toggle(k as keyof typeof outputs)}
+                    />
+                    <span className="ml-3 text-gray-700 font-medium">{label}</span>
+                  </label>
+                </summary>
+                <div className="flex flex-col gap-2 p-4 border-t">
+                  <input
+                    value={overrides[k].path}
+                    onChange={(e) => updateOverride(k, 'path', e.target.value)}
+                    placeholder="Path"
+                    className="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded-xl text-[#101518] focus:outline-0 focus:ring-0 border border-[#d4dce2] bg-gray-50 focus:border-[#d4dce2] h-10 placeholder:text-[#5c748a] p-[10px] text-base font-normal leading-normal"
+                  />
+                  <input
+                    value={overrides[k].owner}
+                    onChange={(e) => updateOverride(k, 'owner', e.target.value)}
+                    placeholder="Owner"
+                    className="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded-xl text-[#101518] focus:outline-0 focus:ring-0 border border-[#d4dce2] bg-gray-50 focus:border-[#d4dce2] h-10 placeholder:text-[#5c748a] p-[10px] text-base font-normal leading-normal"
+                  />
+                  <input
+                    value={overrides[k].repo}
+                    onChange={(e) => updateOverride(k, 'repo', e.target.value)}
+                    placeholder="Repo"
+                    className="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded-xl text-[#101518] focus:outline-0 focus:ring-0 border border-[#d4dce2] bg-gray-50 focus:border-[#d4dce2] h-10 placeholder:text-[#5c748a] p-[10px] text-base font-normal leading-normal"
+                  />
+                  <input
+                    value={overrides[k].mainBranch}
+                    onChange={(e) => updateOverride(k, 'mainBranch', e.target.value)}
+                    placeholder="Main Branch"
+                    className="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded-xl text-[#101518] focus:outline-0 focus:ring-0 border border-[#d4dce2] bg-gray-50 focus:border-[#d4dce2] h-10 placeholder:text-[#5c748a] p-[10px] text-base font-normal leading-normal"
+                  />
+                </div>
+              </details>
+            );
+          })}
+          <label className="flex items-center p-4 border border-gray-200 rounded-lg cursor-not-allowed bg-gray-100 shadow-sm opacity-50 select-none">
             <input
               className="form-radio h-5 w-5 text-teal-600 border-gray-400"
-              name="outputType"
               type="checkbox"
               value="kotlin"
-              // checked={outputs.kt}
               onChange={() => toggle('kt')}
               disabled
             />
-            <span className="ml-3 text-gray-400 font-medium">
-              kotlin - coming soon
-            </span>
+            <span className="ml-3 text-gray-400 font-medium">kotlin - coming soon</span>
           </label>
         </div>
         <input

--- a/ui/store.tsx
+++ b/ui/store.tsx
@@ -26,6 +26,13 @@ const defaultGithubForm: IFormGithub = {
   commitMessage: '',
   pullRequestTitle: '',
   mainBranch: '',
+  overrides: {
+    svg: { path: '', owner: '', repo: '', mainBranch: '' },
+    symbol: { path: '', owner: '', repo: '', mainBranch: '' },
+    example: { path: '', owner: '', repo: '', mainBranch: '' },
+    sf: { path: '', owner: '', repo: '', mainBranch: '' },
+    json: { path: '', owner: '', repo: '', mainBranch: '' },
+  },
   exampleFiles: [],
   svgSymbol: '',
   sfSymbols: [],


### PR DESCRIPTION
## Summary
- support per-output GitHub configuration
- keep defaults for existing commit behaviour
- expose new accordion UI to edit owner/repo/path/main branch per output

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859e85e260c83259415a3668b09aed4