### PR TITLE
Add Kotlin Jetpack Compose converter

### DIFF
--- a/shared/kotlin/svgToCompose.ts
+++ b/shared/kotlin/svgToCompose.ts
@@ -1,0 +1,57 @@
+import { load } from 'cheerio';
+
+export function parsePathData(d: string): string {
+  return d
+    .replace(/([MLHVCSQTAZmlhvcsqtaz])/g, '\n$1 ')
+    .trim()
+    .split('\n')
+    .map((cmd) => {
+      const [command, ...args] = cmd.trim().split(/[\s,]+/);
+      const floatArgs = args.map((n) => parseFloat(n));
+      switch (command) {
+        case 'M':
+          return `moveTo(${floatArgs[0]}f, ${floatArgs[1]}f)`;
+        case 'L':
+          return `lineTo(${floatArgs[0]}f, ${floatArgs[1]}f)`;
+        case 'H':
+          return `horizontalLineTo(${floatArgs[0]}f)`;
+        case 'V':
+          return `verticalLineTo(${floatArgs[0]}f)`;
+        case 'Z':
+        case 'z':
+          return 'close()';
+        default:
+          return `/* Unsupported command: ${command} */`;
+      }
+    })
+    .join('\n            ');
+}
+
+export function svgToCompose(svg: string, name = 'MyIcon'): string {
+  const $ = load(svg);
+  const svgNode = $('svg');
+  const path = $('path').attr('d') || '';
+  const width = parseFloat(svgNode.attr('width') || '24');
+  const height = parseFloat(svgNode.attr('height') || '24');
+  const vbParts = (svgNode.attr('viewBox') || `0 0 ${width} ${height}`).split(/\s+/);
+  const vbWidth = parseFloat(vbParts[2]) || width;
+  const vbHeight = parseFloat(vbParts[3]) || height;
+
+  return `val ${name.replace(/[-\s]/g, '_')} = ImageVector.Builder(
+    name = \"${name}\",
+    defaultWidth = ${width}.dp,
+    defaultHeight = ${height}.dp,
+    viewportWidth = ${vbWidth}f,
+    viewportHeight = ${vbHeight}f
+).apply {
+    path(
+        fill = SolidColor(Color.Black),
+        stroke = null,
+        strokeLineWidth = 0.0f,
+        pathFillType = PathFillType.NonZero
+    ) {
+            ${parsePathData(path)}
+    }
+}.build()`;
+}
+

--- a/testes/generateCompose.test.ts
+++ b/testes/generateCompose.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { svgToCompose } from '../shared/kotlin/svgToCompose';
+
+const svg = '<svg width="24" height="24" viewBox="0 0 24 24"><path d="M0 0 L10 10 Z"/></svg>';
+
+describe('svgToCompose', () => {
+  it('converts basic path to compose code', () => {
+    const result = svgToCompose(svg, 'TestIcon');
+    expect(result).toContain('ImageVector.Builder');
+    expect(result).toContain('moveTo(0f, 0f)');
+    expect(result).toContain('lineTo(10f, 10f)');
+    expect(result).toContain('close()');
+  });
+});
+


### PR DESCRIPTION
## Summary
- add module to convert SVG into Jetpack Compose `ImageVector`
- test conversion logic with vitest

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6861876868c483258a6cc8617228221c