### PR TITLE
feat: add DOM parser fallback

### DIFF
--- a/shared/utils/convertFillRule.ts
+++ b/shared/utils/convertFillRule.ts
@@ -1,6 +1,10 @@
 import svgpath from 'svgpath';
 import { parseSVG } from 'svg-path-parser';
 import { reverse as reversePath } from 'svg-path-reverse';
+import {
+  DOMParser as XmldomDOMParser,
+  XMLSerializer as XmldomXMLSerializer,
+} from '@xmldom/xmldom';
 
 (
   svgpath as unknown as {
@@ -79,9 +83,11 @@ function commandToSegment(cmd: Command): Segment {
  * @returns Updated SVG string or Document (same type as input).
  */
 export function convertFillRule(svg: string | Document): string | Document {
+  const Parser =
+    typeof DOMParser === 'undefined' ? XmldomDOMParser : DOMParser;
   const doc =
     typeof svg === 'string'
-      ? new DOMParser().parseFromString(svg, 'image/svg+xml')
+      ? new Parser().parseFromString(svg, 'image/svg+xml')
       : svg;
 
   const docAny = doc as unknown as {
@@ -128,5 +134,9 @@ export function convertFillRule(svg: string | Document): string | Document {
     path.setAttribute('fill-rule', 'nonzero');
   });
 
-  return typeof svg === 'string' ? new XMLSerializer().serializeToString(doc) : doc;
+  const Serializer =
+    typeof XMLSerializer === 'undefined'
+      ? XmldomXMLSerializer
+      : XMLSerializer;
+  return typeof svg === 'string' ? new Serializer().serializeToString(doc) : doc;
 }

--- a/testes/convertFillRule.test.ts
+++ b/testes/convertFillRule.test.ts
@@ -1,10 +1,6 @@
-import { describe, it, expect } from 'vitest';
-import { DOMParser, XMLSerializer } from '@xmldom/xmldom';
+import { DOMParser } from '@xmldom/xmldom';
+import { describe, expect, it } from 'vitest';
 import { convertFillRule } from '../shared/utils/convertFillRule';
-
-(globalThis as unknown as { DOMParser: typeof DOMParser }).DOMParser = DOMParser;
-(globalThis as unknown as { XMLSerializer: typeof XMLSerializer }).XMLSerializer =
-  XMLSerializer;
 
 describe('convertFillRule', () => {
   const svg = '<svg xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M0 0L10 0L10 10L0 10ZM2 2L8 2L8 8L2 8Z"/></svg>';


### PR DESCRIPTION
## Summary
- ensure `convertFillRule` works without native DOM by falling back to `@xmldom/xmldom`
- streamline tests to use local DOM parser

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688ebd79297083259c68ad5847c935d9