### PR TITLE
Improve svg path handling and add type declarations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,8 @@
         "@types/node": "^24.0.3",
         "@types/react": "^19.1.2",
         "@types/react-dom": "^19.1.3",
+        "@types/svg-path-parser": "^1.1.6",
+        "@types/svg-path-reverse": "^1.7.0",
         "@vitejs/plugin-react": "^4.4.1",
         "@xmldom/xmldom": "^0.9.8",
         "dotenv-cli": "^8.0.0",
@@ -1974,6 +1976,20 @@
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
+    },
+    "node_modules/@types/svg-path-parser": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@types/svg-path-parser/-/svg-path-parser-1.1.6.tgz",
+      "integrity": "sha512-3sw6pk91pEtW6W7hRrJ9ZkAgPiJSaNdh7iY8rVOy7buajpQuy2J9A0ZUaiOVcbFvl0p7J+Ne4012muCE/MB+hQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/svg-path-reverse": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@types/svg-path-reverse/-/svg-path-reverse-1.7.0.tgz",
+      "integrity": "sha512-gm/Ox0AwDvqNQ4ip4i+cA0rZL9TcUojTpV1K61DRPgxCgq6WF15xMhkFZA1rdE62mAQzjt8U6tH/38jUZsR17A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.31.1",
@@ -6320,6 +6336,18 @@
       "integrity": "sha512-rJXC08OG0h3W6wDMFxQrZF00Kq6qQvw0djHRdzl3U5DnIERz0MRce3WVc7IS6JYBwtaP/DwYtRRjVlvivNveKg==",
       "dev": true,
       "requires": {}
+    },
+    "@types/svg-path-parser": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@types/svg-path-parser/-/svg-path-parser-1.1.6.tgz",
+      "integrity": "sha512-3sw6pk91pEtW6W7hRrJ9ZkAgPiJSaNdh7iY8rVOy7buajpQuy2J9A0ZUaiOVcbFvl0p7J+Ne4012muCE/MB+hQ==",
+      "dev": true
+    },
+    "@types/svg-path-reverse": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@types/svg-path-reverse/-/svg-path-reverse-1.7.0.tgz",
+      "integrity": "sha512-gm/Ox0AwDvqNQ4ip4i+cA0rZL9TcUojTpV1K61DRPgxCgq6WF15xMhkFZA1rdE62mAQzjt8U6tH/38jUZsR17A==",
+      "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "8.31.1",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,8 @@
     "@types/node": "^24.0.3",
     "@types/react": "^19.1.2",
     "@types/react-dom": "^19.1.3",
+    "@types/svg-path-parser": "^1.1.6",
+    "@types/svg-path-reverse": "^1.7.0",
     "@vitejs/plugin-react": "^4.4.1",
     "@xmldom/xmldom": "^0.9.8",
     "dotenv-cli": "^8.0.0",

--- a/plugin/tsconfig.json
+++ b/plugin/tsconfig.json
@@ -4,6 +4,7 @@
         "noEmit": true,
         "target": "es6",
         "moduleResolution": "node",
+        "allowSyntheticDefaultImports": true,
         
         "typeRoots": [
             "../node_modules/@types",

--- a/ui/tsconfig.app.json
+++ b/ui/tsconfig.app.json
@@ -9,11 +9,12 @@
       "DOM",
       "DOM.Iterable"
     ],
-    "module": "ESNext",
-    "skipLibCheck": true,
+      "module": "ESNext",
+      "skipLibCheck": true,
+      "allowSyntheticDefaultImports": true,
 
     /* Bundler mode */
-    "moduleResolution": "bundler",
+      "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
     "resolveJsonModule": true,
     "isolatedModules": true,


### PR DESCRIPTION
## Summary
- improve type safety in `convertFillRule` by defining `SvgPathWithSegments` and extending `svgpath` prototype
- allow synthetic default imports in TypeScript configs and add missing `svg-path-*` type declarations

## Testing
- `npm run lint`
- `npm run plugin:tsc`
- `npm run ui:tsc`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688fd5fdd1a883259eb6a82269cee7fd