### PR TITLE
Ensure SF symbols regenerate after fill-rule revert

### DIFF
--- a/ui/screens/icons-screen.tsx
+++ b/ui/screens/icons-screen.tsx
@@ -85,15 +85,15 @@ export default function IconsScreen() {
           ? (convertFillRule(icon.originalSvg) as string)
           : icon.originalSvg;
         updated[index] = { ...icon, svg: newSvg };
-        setSvgSymbol(
-          generateSvgSymbol(
-            updated.map((i) => ({
-              name: i.figmaName,
-              id: i.id,
-              svg: i.svg,
-              tags: i.tags,
-            })),
-          ),
+        const updatedFiles = updated.map((i) => ({
+          name: i.figmaName,
+          id: i.id,
+          svg: i.svg,
+          tags: i.tags,
+        }));
+        setSvgSymbol(generateSvgSymbol(updatedFiles));
+        setSFSymbols(
+          generateSFSymbol(template, updatedFiles, sfVariations, sfSize),
         );
       }
       return updated;


### PR DESCRIPTION
## Summary
- regenerate SF symbols when toggling fill-rule reversion to keep outputs in sync

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68934ed5bc6c8325a188492015475de0