### PR TITLE
feat: add support for more svg path commands

### DIFF
--- a/testes/generateCompose.test.ts
+++ b/testes/generateCompose.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { svgToCompose } from '../shared/kotlin/svgToCompose';
 
 const svg = '<svg width="24" height="24" viewBox="0 0 24 24"><path d="M0 0 L10 10 Z"/></svg>';
+const svgCurves = '<svg width="24" height="24" viewBox="0 0 24 24"><path d="M0 0 C10 10 20 20 30 30 Q40 40 50 50 Z"/></svg>';
 
 describe('svgToCompose', () => {
   it('converts basic path to compose code', () => {
@@ -10,6 +11,13 @@ describe('svgToCompose', () => {
     expect(result).toContain('moveTo(0f, 0f)');
     expect(result).toContain('lineTo(10f, 10f)');
     expect(result).toContain('close()');
+  });
+
+  it('supports curve and quadratic commands', () => {
+    const result = svgToCompose(svgCurves, 'CurvyIcon');
+    expect(result).toContain('curveTo(10f, 10f, 20f, 20f, 30f, 30f)');
+    expect(result).toContain('quadTo(40f, 40f, 50f, 50f)');
+    expect(result).not.toContain('Unsupported command');
   });
 });
 

--- a/testes/generateCompose.test.ts
+++ b/testes/generateCompose.test.ts
@@ -3,6 +3,7 @@ import { svgToCompose } from '../shared/kotlin/svgToCompose';
 
 const svg = '<svg width="24" height="24" viewBox="0 0 24 24"><path d="M0 0 L10 10 Z"/></svg>';
 const svgCurves = '<svg width="24" height="24" viewBox="0 0 24 24"><path d="M0 0 C10 10 20 20 30 30 Q40 40 50 50 Z"/></svg>';
+const svgMulti = '<svg width="24" height="24" viewBox="0 0 24 24"><path d="M0 0 L5 5 Z" fill="#ff0000"/><path d="M5 5 L10 10 Z" fill="white"/></svg>';
 
 describe('svgToCompose', () => {
   it('converts basic path to compose code', () => {
@@ -18,6 +19,13 @@ describe('svgToCompose', () => {
     expect(result).toContain('curveTo(10f, 10f, 20f, 20f, 30f, 30f)');
     expect(result).toContain('quadTo(40f, 40f, 50f, 50f)');
     expect(result).not.toContain('Unsupported command');
+  });
+
+  it('converts multiple paths with fill colors', () => {
+    const result = svgToCompose(svgMulti, 'MultiIcon');
+    expect(result.match(/path\(/g)?.length).toBe(2);
+    expect(result).toContain('SolidColor(Color(0xFFFF0000))');
+    expect(result).toContain('SolidColor(Color.White)');
   });
 });
 


### PR DESCRIPTION
## Summary
- parse svg path data with svg-path-parser to support curve, quad and arc commands in Kotlin output
- test Kotlin generation for cubic and quadratic paths

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68935588894c8325a5e04f7780418711