### PR TITLE
feat: allow configuring kotlin package

### DIFF
--- a/plugin/github.ts
+++ b/plugin/github.ts
@@ -187,6 +187,7 @@ export const commitToGithub = async (
     sfSymbols,
     jsonFile,
     filesName,
+    kotlinPackage,
     svgs,
     overrides,
   } = githubData;
@@ -246,7 +247,7 @@ export const commitToGithub = async (
     }
 
     if (outputs.kt && svgs) {
-      const kotlinFiles = generateComposeFile(svgs);
+      const kotlinFiles = generateComposeFile(svgs, kotlinPackage);
       addGroup(
         'kt',
         kotlinFiles.map((f) => ({ path: `kotlin/${f.name}`, content: f.content })),

--- a/shared/types/typings.ts
+++ b/shared/types/typings.ts
@@ -52,6 +52,7 @@ export interface IFormGithub {
   sfSymbols: string[];
   jsonFile: IJsonType[];
   filesName: string;
+  kotlinPackage: string;
   svgs?: ISerializedSVG[];
 }
 
@@ -75,6 +76,8 @@ export interface Store {
   setJsonFile: React.Dispatch<React.SetStateAction<IJsonType[]>>;
   filesName: string;
   setFilesName: React.Dispatch<React.SetStateAction<string>>;
+  kotlinPackage: string;
+  setKotlinPackage: React.Dispatch<React.SetStateAction<string>>;
   sfSize: number;
   setSfSize: React.Dispatch<React.SetStateAction<number>>;
   sfVariations: Set<string>;

--- a/testes/generateComposeFile.test.ts
+++ b/testes/generateComposeFile.test.ts
@@ -14,4 +14,8 @@ describe('generateComposeFile', () => {
     expect(files[0].content).toContain('val IconOne');
     expect(files[0].content).toContain('ImageVector.Builder');
   });
+  it('uses provided kotlin package', () => {
+    const files = generateComposeFile(icons, 'com.test.icons');
+    expect(files[0].content).toContain('package com.test.icons');
+  });
 });

--- a/ui/screens/config-screen.tsx
+++ b/ui/screens/config-screen.tsx
@@ -9,6 +9,8 @@ export default function ConfigScreen() {
     setSfVariations,
     filesName,
     setFilesName,
+    kotlinPackage,
+    setKotlinPackage,
   } = useStore();
   const [custom, setCustom] = useState(String(sfSize));
 
@@ -113,6 +115,14 @@ export default function ConfigScreen() {
         </p>
       </section>
       <div className="flex flex-wrap items-end gap-4 px-4 py-3">
+        <label className="flex flex-col min-w-40 flex-1">
+          <input
+            placeholder="Kotlin package"
+            value={kotlinPackage}
+            onChange={(e) => setKotlinPackage(e.target.value)}
+            className="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded-xl text-[#101518] focus:outline-0 focus:ring-0 border border-[#d4dce2] bg-gray-50 focus:border-[#d4dce2] h-14 placeholder:text-[#5c748a] p-[15px] text-base font-normal leading-normal"
+          />
+        </label>
         <label className="flex flex-col min-w-40 flex-1">
           <input
             placeholder="Files Name"

--- a/ui/screens/github-screen.tsx
+++ b/ui/screens/github-screen.tsx
@@ -11,6 +11,7 @@ export default function GithubScreen() {
     jsonFile,
     exampleFiles,
     filesName,
+    kotlinPackage,
     setAlertMessage,
   } = useStore();
   const { outputs } = githubForm;
@@ -84,6 +85,7 @@ export default function GithubScreen() {
       sfSymbols,
       jsonFile,
       filesName,
+      kotlinPackage,
     };
     setGithubForm(newForm);
     parent.postMessage(
@@ -157,6 +159,7 @@ export default function GithubScreen() {
             pullRequestTitle,
             mainBranch,
             overrides,
+            kotlinPackage,
           },
         },
       },
@@ -173,6 +176,7 @@ export default function GithubScreen() {
     pullRequestTitle,
     mainBranch,
     overrides,
+    kotlinPackage,
   ]);
 
   return (

--- a/ui/screens/icons-screen.tsx
+++ b/ui/screens/icons-screen.tsx
@@ -37,6 +37,8 @@ export default function IconsScreen() {
     exampleFiles,
     setExampleFiles,
     setFilesName,
+    kotlinPackage,
+    setKotlinPackage,
     useVectorChildren,
     setUseVectorChildren,
     setGithubForm,
@@ -157,7 +159,7 @@ export default function IconsScreen() {
     }
     if (outputs.kt) {
       const ktFolder = zip.folder('kotlin');
-      const kotlinFiles = generateComposeFile(json);
+      const kotlinFiles = generateComposeFile(json, kotlinPackage);
       kotlinFiles.forEach((f) => {
         ktFolder?.file(f.name, f.content);
       });
@@ -225,6 +227,7 @@ export default function IconsScreen() {
           if (data.filesName) setFilesName(data.filesName);
           if (typeof data.useVectorChildren === 'boolean')
             setUseVectorChildren(data.useVectorChildren);
+          if (data.kotlinPackage) setKotlinPackage(data.kotlinPackage);
         },
         githubData: () => {
           if (!data) return;
@@ -245,6 +248,7 @@ export default function IconsScreen() {
             ...data,
             overrides: mergedOverrides,
           });
+          if (data.kotlinPackage) setKotlinPackage(data.kotlinPackage);
         },
         tags: () => {
           const { id, tags } = event.data.pluginMessage;
@@ -283,12 +287,13 @@ export default function IconsScreen() {
             sfVariations: Array.from(sfVariations),
             filesName,
             useVectorChildren,
+            kotlinPackage,
           },
         },
       },
       '*',
     );
-  }, [outputs, sfSize, sfVariations, filesName, useVectorChildren]);
+  }, [outputs, sfSize, sfVariations, filesName, useVectorChildren, kotlinPackage]);
 
   function toggle(name: keyof typeof outputs) {
     setOutputs({ ...outputs, [name]: !outputs[name] });
@@ -313,6 +318,7 @@ export default function IconsScreen() {
             sfVariations: Array.from(sfVariations),
             filesName,
             useVectorChildren,
+            kotlinPackage,
           },
         },
       },

--- a/ui/store.tsx
+++ b/ui/store.tsx
@@ -39,6 +39,7 @@ export const defaultGithubForm: IFormGithub = {
   sfSymbols: [],
   jsonFile: [],
   filesName: 'icons-symbol',
+  kotlinPackage: 'com.example.icons',
 };
 
 const GlobalContext = createContext<Store | null>(null);
@@ -50,6 +51,7 @@ export const GlobalProvider = ({ children }: { children: React.ReactNode }) => {
   const [jsonFile, setJsonFile] = useState<IJsonType[]>([]);
   const [exampleFiles, setExampleFiles] = useState<ExampleFile[]>([]);
   const [filesName, setFilesName] = useState('icons-symbol');
+  const [kotlinPackage, setKotlinPackage] = useState('com.example.icons');
   const [sfSize, setSfSize] = useState<number>(32);
   const [sfVariations, setSfVariations] = useState<Set<string>>(
     new Set(['m-ultralight', 'm-regular', 'm-black']),
@@ -71,6 +73,8 @@ export const GlobalProvider = ({ children }: { children: React.ReactNode }) => {
         setJsonFile,
         filesName,
         setFilesName,
+        kotlinPackage,
+        setKotlinPackage,
         sfSize,
         setSfSize,
         sfVariations,


### PR DESCRIPTION
## Summary
- add Kotlin package field in settings
- generate Kotlin files using chosen package
- pass package to GitHub commits

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6893f0556c78832590f05dccfde76235